### PR TITLE
fix js error when no cookie present, add event 

### DIFF
--- a/resources/js/components/alerts/ctlr/dismissal.js
+++ b/resources/js/components/alerts/ctlr/dismissal.js
@@ -4,25 +4,25 @@ export default {
     props: {
         id: {},
     },
-    data() {
-        return {
-            result: 'bar',
-        }
-    },
     methods: {
         dismiss() {
-            document.getElementById('alert-' + this.id).style.display = 'none';
+            // Emit event to parent component
+            this.$emit('alert-dismissed', this.id)
 
-            let ids = (new Cookies()).get('alerts').split(',');
+            let ids = []
+            const existingIds = (new Cookies()).get('alerts');
+            
+            if (existingIds) {
+              ids = existingIds.split(',');
+            }
+
             ids.push(this.id.toString());
             ids = _.compact(_.uniq(ids));
             ids = ids.join(',');
-
-            //document.cookie = "alerts=" + ids;
-
+            
             let cookie = new Cookies();
             cookie.set('alerts', ids, 7);
         },
     },
-    template: `<div><span @click="dismiss"><slot><i class="fa fa-times"></i></slot></span></div>`
+    template: `<div @click="dismiss"><slot></slot></div>`
 }


### PR DESCRIPTION
If no cookie was present, js would throw an error when it tried to split the contents of the cookie, and fail to execute the rest of the function. I added a quick check to make sure cookie contents exists before splitting and pushing into the array.

I also added a Vue event to notify the parent component when an alert is dismissed. 