### PR TITLE
Place dot properly after saving, watch zoom changes

### DIFF
--- a/resources/js/components/base/coordinates.vue
+++ b/resources/js/components/base/coordinates.vue
@@ -5,13 +5,9 @@
 <script>
 import loadGoogleMapsAPI from 'load-google-maps-api';
 
-let gMap = {};
+let gMap = null;
+let dragSpot = null;
 
-let defaults = {
-    lat: 39.9612,
-    lng: -82.99882,
-    zoom: 15,
-}
 
 export default {
   name: 'coordinates-map',
@@ -32,10 +28,11 @@ export default {
     /**
      * Initilize Map
      */
+
     initMap () {
-
+        // Get zoom from parameter or config
         let zoom = parseInt(this.zoom ? this.zoom : config('zoom', 15));
-
+  
         this.center = new google.maps.LatLng(config('lat'), config('lng'));
 
         gMap = new google.maps.Map(this.$refs.map , {
@@ -47,13 +44,15 @@ export default {
         });
 
         // Set marker default location OR passed in coordinates
-        let dragSpotLocation = this.center
+        let dragSpotLocation = {}
         if (this.lat && this.lng) {
           dragSpotLocation = new google.maps.LatLng(this.lat, this.lng)
+        } else {
+          dragSpotLocation = this.center
         }
 
         // Create draggable marker
-        const dragSpot = new google.maps.Marker({
+        dragSpot = new google.maps.Marker({
           position: dragSpotLocation,
           map: gMap,
           draggable: true,
@@ -78,9 +77,33 @@ export default {
 
         return Promise.resolve();
     },
-    centerSpot() {
-    }
 
+    /** 
+     * Update Dragspot Location
+     */
+
+    updateDragSpotLocation () {
+      if (dragSpot && gMap) {
+        const updatedPosition = new google.maps.LatLng(this.lat, this.lng)
+        dragSpot.setPosition(updatedPosition)
+        gMap.setCenter(updatedPosition)
+      }
+    },
+
+    centerSpot() {}
+  },
+  watch: {
+    zoom: function (val) {
+      if (gMap) {
+        gMap.setZoom(parseInt(val))
+      }
+    },
+    lat: function (val) {
+      this.updateDragSpotLocation()
+    },
+    lng: function (val) {
+      this.updateDragSpotLocation()
+    }
   }
 }
 


### PR DESCRIPTION
Lots of changes re: dot placement.  The true lat/lng get passed in after the map is mounted typically so I had to make a few adjustments to handle that scenario.

I added a watcher on the zoom parameter, so when you update the zoom level in the form field, it auto updates the map.

__ 

Just a heads up Zoom Level is not currently saving