### PR TITLE
switch langauage from scss to sass

### DIFF
--- a/resources/belt/core/js/base/modals/modal-delete.vue
+++ b/resources/belt/core/js/base/modals/modal-delete.vue
@@ -62,7 +62,7 @@
 
 </script>
 
-<style lang="scss" scoped>
+<style lang="sass" scoped>
     .modal-delete-trigger {
         cursor: pointer;
     }


### PR DESCRIPTION
Turns out that the warning we were seeing yesterday does effect the admin.  (it breaks when you try to go into a route).  I spent a good bit of time trying to get rid of the error. Unfortunately I can't get it to compile as is with the latest version of Laravel Mix, but if we make a minor change, everything works fine:

https://laracasts.com/discuss/channels/vue/cannot-compile-vue-modules-with-scss